### PR TITLE
Ipad Rotation (home button right) and inmobiSDK pod install

### DIFF
--- a/iOS/BattleBuddy/Info.plist
+++ b/iOS/BattleBuddy/Info.plist
@@ -79,7 +79,7 @@
 		<string>UIInterfaceOrientationPortrait</string>
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeChestRight</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>

--- a/iOS/Podfile
+++ b/iOS/Podfile
@@ -20,5 +20,5 @@ target 'BattleBuddy' do
   pod 'Crashlytics', '~> 3.13.4'
   pod 'JGProgressHUD'
   pod "YoutubePlayer-in-WKWebView", "~> 0.3.0"
-  pod 'inmobi-ios-sdk', :source => 'https://bitbucket.org/aerservllc/inmobi-ios-sdk-pod.git'
+  pod 'InMobiSDK'
 end

--- a/iOS/Podfile.lock
+++ b/iOS/Podfile.lock
@@ -141,7 +141,14 @@ PODS:
     - nanopb (~> 0.3)
   - gRPC-Core/Interface (1.21.0)
   - GTMSessionFetcher/Core (1.2.2)
-  - inmobi-ios-sdk (8.2.0)
+  - InMobiSDK (9.0.7):
+    - InMobiSDK/InMobiSDK (= 9.0.7)
+  - InMobiSDK/Core (9.0.7)
+  - InMobiSDK/InMobiSDK (9.0.7):
+    - InMobiSDK/Core
+    - InMobiSDK/Moat
+  - InMobiSDK/Moat (9.0.7):
+    - InMobiSDK/Core
   - JGProgressHUD (2.0.4)
   - leveldb-library (1.22)
   - nanopb (0.3.901):
@@ -167,15 +174,13 @@ DEPENDENCIES:
   - Firebase/Messaging
   - Firebase/Storage
   - FirebaseUI/Storage
-  - inmobi-ios-sdk
+  - InMobiSDK
   - JGProgressHUD
   - SDWebImage (~> 5.0)
   - YoutubePlayer-in-WKWebView (~> 0.3.0)
 
 SPEC REPOS:
-  https://bitbucket.org/aerservllc/inmobi-ios-sdk-pod.git:
-    - inmobi-ios-sdk
-  https://github.com/cocoapods/specs.git:
+  trunk:
     - Alamofire
     - BoringSSL-GRPC
     - Crashlytics
@@ -201,6 +206,7 @@ SPEC REPOS:
     - "gRPC-C++"
     - gRPC-Core
     - GTMSessionFetcher
+    - InMobiSDK
     - JGProgressHUD
     - leveldb-library
     - nanopb
@@ -234,7 +240,7 @@ SPEC CHECKSUMS:
   "gRPC-C++": 9dfe7b44821e7b3e44aacad2af29d2c21f7cde83
   gRPC-Core: c9aef9a261a1247e881b18059b84d597293c9947
   GTMSessionFetcher: 61bb0f61a4cb560030f1222021178008a5727a23
-  inmobi-ios-sdk: 8d967db61692680675d86104bf5111c9a9520738
+  InMobiSDK: c3ec3fed998d8431ba31ad16565d102159e3f9e3
   JGProgressHUD: 62658b14e72cccf179efc7a13bcb54d30b92fc22
   leveldb-library: 55d93ee664b4007aac644a782d11da33fba316f7
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
@@ -242,6 +248,6 @@ SPEC CHECKSUMS:
   SDWebImage: 96d7f03415ccb28d299d765f93557ff8a617abd8
   YoutubePlayer-in-WKWebView: f9c20a456c5d99e5f5248e4d2079a5d3b6950d13
 
-PODFILE CHECKSUM: d26419a9955b0a9ce3ac923bb9feb41ff673f506
+PODFILE CHECKSUM: 8a067a6f049df7a9a2919f4a3d0a84b8d2a02f81
 
-COCOAPODS: 1.7.5
+COCOAPODS: 1.9.3


### PR DESCRIPTION
Fixes the problem with iPadOS not being able to rotate to 'home button right' with the newest version of BattleBuddy. Which is problematic for use with keyboard accessory attached to the iPad.

This also includes changing the inmobiSDK to use the pod named version as apposed to the bitbucket link. The link within that repo is supposed to point to the zip file of inmobisdk but the link is giving an 'AccessDenied' message. Updated the pod.lock file in the process.