### PR TITLE
Hide keyboard on Price Check screen

### DIFF
--- a/iOS/BattleBuddy/Source/View/View Controllers/Learn/PriceCheckViewController.swift
+++ b/iOS/BattleBuddy/Source/View/View Controllers/Learn/PriceCheckViewController.swift
@@ -91,8 +91,10 @@ extension PriceCheckViewController: UISearchBarDelegate {
 // MARK: - UIScrollViewDelegate
 
 extension PriceCheckViewController {
-    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        searchBar.resignFirstResponder()
+    override func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        if searchBar.isFirstResponder {
+            searchBar.resignFirstResponder()
+        }
     }
 }
 

--- a/iOS/BattleBuddy/Source/View/View Controllers/Learn/PriceCheckViewController.swift
+++ b/iOS/BattleBuddy/Source/View/View Controllers/Learn/PriceCheckViewController.swift
@@ -82,6 +82,10 @@ extension PriceCheckViewController: UISearchBarDelegate {
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
         controller.updateSearchText(searchText)
     }
+
+    func searchBarSearchButtonClicked(_ searchBar: UISearchBar) {
+        searchBar.resignFirstResponder()
+    }
 }
 
 // MARK: - UIScrollViewDelegate

--- a/iOS/BattleBuddy/Source/View/View Controllers/Learn/PriceCheckViewController.swift
+++ b/iOS/BattleBuddy/Source/View/View Controllers/Learn/PriceCheckViewController.swift
@@ -84,6 +84,14 @@ extension PriceCheckViewController: UISearchBarDelegate {
     }
 }
 
+// MARK: - UIScrollViewDelegate
+
+extension PriceCheckViewController {
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        searchBar.resignFirstResponder()
+    }
+}
+
 extension PriceCheckViewController: PriceCheckControllerDelegate {
     func resultsDidChange() {
         tableView.reloadData()


### PR DESCRIPTION
### Summary

As of right now the UX with keyboard on Price Check screen is not very friendly, to be more precise there's no way to hide it:
![RocketSim Recording - iPhone X 13 6 - 2020-08-02 16 45 07](https://user-images.githubusercontent.com/6040314/89132092-9fae0980-d4df-11ea-9694-03b4bc427972.gif)

This PR fixes this by hiding keyboard either on scrolling or when user presses "search":
![RocketSim Recording - iPhone X 13 6 - 2020-08-02 16 47 30](https://user-images.githubusercontent.com/6040314/89132138-e4d23b80-d4df-11ea-8b9c-927b0407afb9.gif)

Encourage you to try for yourself :) 

**UPD** Lol PR #69  :D 